### PR TITLE
chore(repo): bootstrap daily log structure + add 2025-08-12 summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # killer_joki_-development_story
+
+A repository to track and organize daily development work summaries.
+
+## Structure
+- `summaries/YYYY/MM/DATE.md` — daily summaries organized by year and month
+- `templates/daily-summary-template.md` — reusable template for new entries
+
+## How to add a new daily summary
+1. Copy `templates/daily-summary-template.md` to `summaries/YYYY/MM/YYYY-MM-DD.md`
+2. Fill in each section concisely. Keep technical details, links, and follow-ups clear.
+3. Commit with a message like:
+   - `docs: add YYYY-MM-DD work summary`
+
+## Optional integrations
+- Notion: mirror the content to your Notion space (page: "개인 공부").
+- GitHub PRs: use a branch like `chore/daily-log-YYYY-MM-DD` and open a PR to `main`.

--- a/summaries/2025/08/2025-08-12.md
+++ b/summaries/2025/08/2025-08-12.md
@@ -1,0 +1,51 @@
+# Daily Summary — 2025-08-12
+
+Date: 2025-08-12
+
+## Overview
+- Set up MCP codemod tooling to automatically fix common Vue warnings and safety issues.
+- Resolved multiple Vue console warnings (conditional @search handlers, CmpIcons slot usage) and improved DX.
+- Tuned Vite build for Nx + Module Federation to reduce warnings and improve performance.
+- Planned PoC for Figma MCP integration to generate Vue components from designs.
+
+## Details
+### MCP codemod: vue-warnings
+- Script: `tools/mcp/codemods/vue-warnings.mjs`
+- Exposed via `.mcp/commands.json` as `vue_warnings` (supports dry-run and write modes)
+- Targets:
+  - Conditional `@search` binding (only when `showSearch` is true)
+  - `CmpUploader` v-model:file-list binding and existing file list normalization
+  - `CmpIcons` slot usage switched to function slots for performance
+
+### Vue warnings resolved
+1) CmpDropdown onSearch warning
+   - Problem: `@search` used without `showSearch`
+   - Fix: `v-on="showSearch ? { search: onSearch } : {}"`
+2) CmpSelect onSearch warning (Template Update Modal path)
+   - Fix: `v-on="showSearch ? { search: handleSearch } : {}"`
+3) useNotification CmpIcons slot warning
+   - Fix: `h(CmpIcons, props, () => iconName)`
+
+### Vite / Nx / Module Federation optimizations
+- Security warning suppression for `@module-federation/sdk` (no eval bundled)
+  - rollupOptions.external: `/@module-federation\\/sdk/`
+  - optimizeDeps.exclude: `@module-federation/sdk`
+  - esbuild define: `global: 'globalThis'`
+- Build performance
+  - `reportCompressedSize: false`, increased `chunkSizeWarningLimit`, `emptyOutDir: true`
+  - `manualChunks` to split vendor from app
+  - Pre-bundle: `vue`, `vue-router`, `pinia`, `@vueuse/core`
+  - esbuild: `treeShaking`, remove `legalComments`, dev-only sourcemaps
+
+### Project environment context
+- pnpm 10.4.1 required
+- Nx monorepo with Module Federation; admin-console depends on remoteMaestro (port 18200)
+
+### Notion
+- Created page: "2025-08-12 작업 정리" under "개인 공부" (link can be added later)
+
+## Next steps
+- Expand codemod coverage to additional Vue warning patterns
+- Start Figma MCP PoC for component generation
+- Further tune Vite based on build/cache metrics
+- Consider richer Notion templates (checklists, toggles)

--- a/templates/daily-summary-template.md
+++ b/templates/daily-summary-template.md
@@ -1,0 +1,25 @@
+# Daily Summary Template
+
+Date: YYYY-MM-DD
+
+## Overview
+- Concise, high-level summary of what was done today.
+
+## Details
+### Changes / Fixes
+- What changed, where, and why.
+
+### Tooling / Infra
+- Any build, CI/CD, or tooling improvements.
+
+### Docs / Knowledge
+- Links to docs, decisions, and references.
+
+## Environment / Context
+- Versions, services, or dependencies that matter.
+
+## Notion
+- Page: <Notion page title or link>
+
+## Next steps
+- Short, actionable follow-ups.


### PR DESCRIPTION
This PR bootstraps the repository for daily development summaries and adds the first entry for 2025-08-12.

What’s included:
- README with structure and contribution guidance
- Daily summary template under `templates/`
- First daily log under `summaries/2025/08/2025-08-12.md`

Suggested workflow:
- Add new entries using the template and follow the commit convention `docs: add YYYY-MM-DD work summary`.
- Optionally mirror to Notion (page: "개인 공부").
