### PR TITLE
docs: KR 버전 초기 구성 및 2025-08-12 일지 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # killer_joki_-development_story
 
-A repository to track and organize daily development work summaries.
+개발 일일 작업 정리를 기록하고 관리하기 위한 저장소입니다.
 
-## Structure
-- `summaries/YYYY/MM/DATE.md` — daily summaries organized by year and month
-- `templates/daily-summary-template.md` — reusable template for new entries
+## 구조
+- `summaries/YYYY/MM/DATE.md` — 연/월별로 정리된 일일 작업 기록
+- `templates/daily-summary-template.md` — 새 기록을 작성할 때 사용하는 템플릿
 
-## How to add a new daily summary
-1. Copy `templates/daily-summary-template.md` to `summaries/YYYY/MM/YYYY-MM-DD.md`
-2. Fill in each section concisely. Keep technical details, links, and follow-ups clear.
-3. Commit with a message like:
-   - `docs: add YYYY-MM-DD work summary`
+## 새 일일 기록 작성 방법
+1. `templates/daily-summary-template.md`를 복사하여 `summaries/YYYY/MM/YYYY-MM-DD.md`로 저장합니다.
+2. 각 섹션을 간결하게 채웁니다. 기술적 내용, 링크, 후속 작업을 명확히 적습니다.
+3. 커밋 메시지 예시:
+   - `docs: YYYY-MM-DD 작업 정리 추가`
 
-## Optional integrations
-- Notion: mirror the content to your Notion space (page: "개인 공부").
-- GitHub PRs: use a branch like `chore/daily-log-YYYY-MM-DD` and open a PR to `main`.
+## 선택 사항(연동)
+- Notion: 같은 내용을 Notion 개인 공부 공간(페이지: "개인 공부")에도 미러링할 수 있습니다.
+- GitHub PR: `chore/daily-log-YYYY-MM-DD` 브랜치를 만들어 `main`으로 PR을 열어 관리할 수 있습니다.

--- a/summaries/2025/08/2025-08-12.md
+++ b/summaries/2025/08/2025-08-12.md
@@ -1,51 +1,51 @@
-# Daily Summary — 2025-08-12
+# 일일 작업 정리 — 2025-08-12
 
-Date: 2025-08-12
+날짜: 2025-08-12
 
-## Overview
-- Set up MCP codemod tooling to automatically fix common Vue warnings and safety issues.
-- Resolved multiple Vue console warnings (conditional @search handlers, CmpIcons slot usage) and improved DX.
-- Tuned Vite build for Nx + Module Federation to reduce warnings and improve performance.
-- Planned PoC for Figma MCP integration to generate Vue components from designs.
+## 개요
+- Vue 경고 및 안전성 이슈를 자동으로 고치는 MCP 코데모드 도구를 도입했습니다.
+- 콘솔 경고(조건부 @search 바인딩, CmpIcons 슬롯 사용)들을 해결하여 DX를 개선했습니다.
+- Nx + Module Federation 환경에 맞춰 Vite 빌드 경고를 줄이고 성능을 향상했습니다.
+- Figma MCP 연동을 통해 디자인에서 Vue 컴포넌트 생성 PoC 방향을 수립했습니다.
 
-## Details
-### MCP codemod: vue-warnings
-- Script: `tools/mcp/codemods/vue-warnings.mjs`
-- Exposed via `.mcp/commands.json` as `vue_warnings` (supports dry-run and write modes)
-- Targets:
-  - Conditional `@search` binding (only when `showSearch` is true)
-  - `CmpUploader` v-model:file-list binding and existing file list normalization
-  - `CmpIcons` slot usage switched to function slots for performance
+## 상세
+### MCP 코데모드: vue-warnings
+- 스크립트: `tools/mcp/codemods/vue-warnings.mjs`
+- `.mcp/commands.json`에 `vue_warnings`로 노출(드라이런/실제 쓰기 모드 지원)
+- 대상:
+  - `@search` 이벤트를 `showSearch`가 true일 때만 바인딩
+  - `CmpUploader`의 `v-model:file-list` 바인딩과 기존 파일 리스트 정규화
+  - `CmpIcons` 슬롯을 문자열이 아닌 함수형 슬롯으로 변경(성능 권장 사항)
 
-### Vue warnings resolved
-1) CmpDropdown onSearch warning
-   - Problem: `@search` used without `showSearch`
-   - Fix: `v-on="showSearch ? { search: onSearch } : {}"`
-2) CmpSelect onSearch warning (Template Update Modal path)
-   - Fix: `v-on="showSearch ? { search: handleSearch } : {}"`
-3) useNotification CmpIcons slot warning
-   - Fix: `h(CmpIcons, props, () => iconName)`
+### 해결한 Vue 경고
+1) CmpDropdown onSearch 경고
+   - 문제: `showSearch` 없이 `@search` 사용
+   - 해결: `v-on="showSearch ? { search: onSearch } : {}"`
+2) CmpSelect onSearch 경고(템플릿 수정 모달 경로)
+   - 해결: `v-on="showSearch ? { search: handleSearch } : {}"`
+3) useNotification CmpIcons 슬롯 경고
+   - 해결: `h(CmpIcons, props, () => iconName)`
 
-### Vite / Nx / Module Federation optimizations
-- Security warning suppression for `@module-federation/sdk` (no eval bundled)
+### Vite / Nx / Module Federation 최적화
+- `@module-federation/sdk` 보안 경고( eval ) 제거
   - rollupOptions.external: `/@module-federation\\/sdk/`
   - optimizeDeps.exclude: `@module-federation/sdk`
   - esbuild define: `global: 'globalThis'`
-- Build performance
-  - `reportCompressedSize: false`, increased `chunkSizeWarningLimit`, `emptyOutDir: true`
-  - `manualChunks` to split vendor from app
-  - Pre-bundle: `vue`, `vue-router`, `pinia`, `@vueuse/core`
-  - esbuild: `treeShaking`, remove `legalComments`, dev-only sourcemaps
+- 빌드 성능
+  - `reportCompressedSize: false`, `chunkSizeWarningLimit` 상향, `emptyOutDir: true`
+  - `manualChunks`로 vendor와 앱 코드 분리
+  - 프리번들: `vue`, `vue-router`, `pinia`, `@vueuse/core`
+  - esbuild: `treeShaking`, `legalComments` 제거, 개발 모드에서만 소스맵
 
-### Project environment context
-- pnpm 10.4.1 required
-- Nx monorepo with Module Federation; admin-console depends on remoteMaestro (port 18200)
+### 프로젝트 환경 컨텍스트
+- pnpm 10.4.1 필요
+- Nx 모노레포 + Module Federation 사용, admin-console은 remoteMaestro(포트 18200)에 의존
 
 ### Notion
-- Created page: "2025-08-12 작업 정리" under "개인 공부" (link can be added later)
+- "개인 공부" 아래에 "2025-08-12 작업 정리" 페이지 생성(링크는 추후 추가 가능)
 
-## Next steps
-- Expand codemod coverage to additional Vue warning patterns
-- Start Figma MCP PoC for component generation
-- Further tune Vite based on build/cache metrics
-- Consider richer Notion templates (checklists, toggles)
+## 다음 단계
+- 코데모드 커버리지 확대(추가 Vue 경고 패턴 반영)
+- Figma MCP PoC 진행(컴포넌트 자동 생성)
+- 빌드/캐시 메트릭 기반 Vite 추가 튜닝
+- Notion 템플릿 고도화(체크리스트/토글 등)

--- a/templates/daily-summary-template.md
+++ b/templates/daily-summary-template.md
@@ -1,25 +1,25 @@
-# Daily Summary Template
+# 일일 작업 정리 템플릿
 
-Date: YYYY-MM-DD
+날짜: YYYY-MM-DD
 
-## Overview
-- Concise, high-level summary of what was done today.
+## 개요
+- 오늘 수행한 핵심 작업을 간결하게 요약합니다.
 
-## Details
-### Changes / Fixes
-- What changed, where, and why.
+## 상세
+### 변경/수정 사항
+- 무엇이, 어디서, 왜 변경되었는지 기록합니다.
 
-### Tooling / Infra
-- Any build, CI/CD, or tooling improvements.
+### 도구/인프라
+- 빌드, CI/CD, 개발 도구 관련 개선 사항을 적습니다.
 
-### Docs / Knowledge
-- Links to docs, decisions, and references.
+### 문서/지식
+- 참고 문서, 결정 사항, 관련 링크 등을 정리합니다.
 
-## Environment / Context
-- Versions, services, or dependencies that matter.
+## 환경/컨텍스트
+- 중요한 버전, 서비스 의존성 등을 기록합니다.
 
 ## Notion
-- Page: <Notion page title or link>
+- 페이지: <Notion 페이지 제목 또는 링크>
 
-## Next steps
-- Short, actionable follow-ups.
+## 다음 단계
+- 짧고 실행 가능한 후속 작업을 나열합니다.


### PR DESCRIPTION
다음 변경으로 한국어 버전 초기 구성을 추가했습니다.

포함 내용:
- README: 저장소 목적/구조/작성 가이드 한글화
- 템플릿: `templates/daily-summary-template.md` 한글 템플릿 추가
- 일지: `summaries/2025/08/2025-08-12.md` — 2025-08-12 작업 정리(한국어)

권장 워크플로우:
- 템플릿 복사 → `summaries/YYYY/MM/YYYY-MM-DD.md` 작성
- 커밋 메시지 예: `docs: YYYY-MM-DD 작업 정리 추가`
- Notion에 동일 내용 미러링(페이지: "개인 공부") 선택 가능
