### PR TITLE
docs: 2025년 8월 개발일지 디렉토리 생성 및 2025-08-12 일지 복구

### DIFF
--- a/2025년 8월 개발일지/2025-08-12.md
+++ b/2025년 8월 개발일지/2025-08-12.md
@@ -1,0 +1,51 @@
+# 일일 작업 정리 — 2025-08-12
+
+날짜: 2025-08-12
+
+## 개요
+- Vue 경고 및 안전성 이슈를 자동으로 고치는 MCP 코데모드 도구를 도입했습니다.
+- 콘솔 경고(조건부 @search 바인딩, CmpIcons 슬롯 사용)들을 해결하여 DX를 개선했습니다.
+- Nx + Module Federation 환경에 맞춰 Vite 빌드 경고를 줄이고 성능을 향상했습니다.
+- Figma MCP 연동을 통해 디자인에서 Vue 컴포넌트 생성 PoC 방향을 수립했습니다.
+
+## 상세
+### MCP 코데모드: vue-warnings
+- 스크립트: `tools/mcp/codemods/vue-warnings.mjs`
+- `.mcp/commands.json`에 `vue_warnings`로 노출(드라이런/실제 쓰기 모드 지원)
+- 대상:
+  - `@search` 이벤트를 `showSearch`가 true일 때만 바인딩
+  - `CmpUploader`의 `v-model:file-list` 바인딩과 기존 파일 리스트 정규화
+  - `CmpIcons` 슬롯을 문자열이 아닌 함수형 슬롯으로 변경(성능 권장 사항)
+
+### 해결한 Vue 경고
+1) CmpDropdown onSearch 경고
+   - 문제: `showSearch` 없이 `@search` 사용
+   - 해결: `v-on="showSearch ? { search: onSearch } : {}"`
+2) CmpSelect onSearch 경고(템플릿 수정 모달 경로)
+   - 해결: `v-on="showSearch ? { search: handleSearch } : {}"`
+3) useNotification CmpIcons 슬롯 경고
+   - 해결: `h(CmpIcons, props, () => iconName)`
+
+### Vite / Nx / Module Federation 최적화
+- `@module-federation/sdk` 보안 경고( eval ) 제거
+  - rollupOptions.external: `/@module-federation\\/sdk/`
+  - optimizeDeps.exclude: `@module-federation/sdk`
+  - esbuild define: `global: 'globalThis'`
+- 빌드 성능
+  - `reportCompressedSize: false`, `chunkSizeWarningLimit` 상향, `emptyOutDir: true`
+  - `manualChunks`로 vendor와 앱 코드 분리
+  - 프리번들: `vue`, `vue-router`, `pinia`, `@vueuse/core`
+  - esbuild: `treeShaking`, `legalComments` 제거, 개발 모드에서만 소스맵
+
+### 프로젝트 환경 컨텍스트
+- pnpm 10.4.1 필요
+- Nx 모노레포 + Module Federation 사용, admin-console은 remoteMaestro(포트 18200)에 의존
+
+### Notion
+- "개인 공부" 아래에 "2025-08-12 작업 정리" 페이지 생성(링크는 추후 추가 가능)
+
+## 다음 단계
+- 코데모드 커버리지 확대(추가 Vue 경고 패턴 반영)
+- Figma MCP PoC 진행(컴포넌트 자동 생성)
+- 빌드/캐시 메트릭 기반 Vite 추가 튜닝
+- Notion 템플릿 고도화(체크리스트/토글 등)


### PR DESCRIPTION
"2025년 8월 개발일지" 디렉토리를 새로 생성하고, 2025-08-12 일지를 한국어로 복구했습니다.

포함 내용:
- 디렉토리: `2025년 8월 개발일지/`
- 파일: `2025-08-12.md` — 2025-08-12 작업 정리(한국어)

필요 시 동일 디렉토리에 일자별로 추가해 나가면 됩니다.