### PR TITLE
docs: MCP - Atlassian 연동 디렉터리 및 초기 문서 추가 (2025-08-14)

### DIFF
--- a/2025년 8월 개발일지/MCP - Atlassian 연동/README.md
+++ b/2025년 8월 개발일지/MCP - Atlassian 연동/README.md
@@ -1,0 +1,22 @@
+# MCP × Atlassian 연동 정리 (2025-08-14)
+
+본 디렉터리는 MCP 기반으로 Confluence/Jira를 연동한 작업 내용을 정리합니다.
+
+- Confluence 가이드: 페이지 생성/업데이트/라벨/코멘트, 퍼블리시 스크립트 사용법
+- Jira 가이드: 이슈/링크/스프린트/전환/워크로그, 검색
+- 보안/운영: 환경변수(.env.mcp), 권한 점검, dry-run
+- 트러블슈팅: 인증, 권한, 스키마, 연결 이슈
+
+참고 링크
+- Confluence: MCP 연동 — Atlassian(Confluence · Jira) 가이드
+  - https://okestro.atlassian.net/wiki/spaces/PCD/pages/2111799452
+- Confluence: MCP 연동 — Figma 자동 생성 가이드
+  - https://okestro.atlassian.net/wiki/spaces/PCD/pages/2111897862
+- Notion: 2025-08-14 - Atlassian X MCP 연동 가이드
+  - https://www.notion.so/2025-08-14-Atlassian-X-MCP-24f3c6e76b8e816f9703d8824fc6e323
+
+구성 파일
+- confluence.md: Confluence 퍼블리시/도구 사용 요약
+- jira.md: Jira 자동화/도구 사용 요약
+- troubleshooting.md: 자주 발생하는 문제 해결
+- scripts.md: 스크립트 개요와 사용법

--- a/2025년 8월 개발일지/MCP - Atlassian 연동/confluence.md
+++ b/2025년 8월 개발일지/MCP - Atlassian 연동/confluence.md
@@ -1,0 +1,23 @@
+# Confluence 가이드
+
+## TL;DR
+- MCP 도구: confluence_create_page, confluence_update_page, confluence_add_label, confluence_add_comment, confluence_search, confluence_get_page
+- 빠른 퍼블리시: scripts/publish-confluence-fast.sh (버전 자동 증가, --dry-run)
+
+## Quick Start
+- .env.mcp 예시
+```
+ATLASSIAN_BASE_URL=https://okestro.atlassian.net
+ATLASSIAN_EMAIL=you@example.com
+ATLASSIAN_API_TOKEN=your_api_token
+ATLASSIAN_CLOUD=true
+CONFLUENCE_SPACES_FILTER=PCD
+```
+- 서버 실행: ./scripts/start-mcp-atlassian.sh
+
+## Common Actions
+- 페이지 생성/업데이트/라벨/코멘트/검색/조회 예시 포함 (Confluence 페이지 참조)
+
+## 참고
+- https://okestro.atlassian.net/wiki/spaces/PCD/pages/2111799452
+- scripts/publish-confluence-fast.sh

--- a/2025년 8월 개발일지/MCP - Atlassian 연동/jira.md
+++ b/2025년 8월 개발일지/MCP - Atlassian 연동/jira.md
@@ -1,0 +1,14 @@
+# Jira 가이드
+
+## TL;DR
+- MCP 도구: jira_create_issue, jira_create_issue_link, jira_create_remote_issue_link, jira_get_agile_boards, jira_create_sprint, jira_get_transitions, jira_transition_issue, jira_add_worklog, jira_create_version, jira_search
+
+## Quick Start
+- .env.mcp에 JIRA_PROJECTS_FILTER 등 설정
+- 서버 실행 후 IDE에서 jira_* 도구 확인
+
+## Common Actions
+- 이슈 생성, 링크, 스프린트, 전환, 작업 로그, 버전, 검색 예시 (Confluence 페이지 참조)
+
+## 참고
+- https://okestro.atlassian.net/wiki/spaces/PCD/pages/2111799452

--- a/2025년 8월 개발일지/MCP - Atlassian 연동/scripts.md
+++ b/2025년 8월 개발일지/MCP - Atlassian 연동/scripts.md
@@ -1,0 +1,11 @@
+# 스크립트 사용법
+
+## publish-confluence-fast.sh
+- curl + jq로 빠르게 Confluence 페이지 생성/업데이트
+- 버전 자동 증가, --dry-run 지원
+
+## start-mcp-atlassian.sh
+- MCP Atlassian 서버 실행 스크립트
+
+## publish-mcp-confluence.sh
+- MCP 도구를 활용한 퍼블리시 유틸

--- a/2025년 8월 개발일지/MCP - Atlassian 연동/troubleshooting.md
+++ b/2025년 8월 개발일지/MCP - Atlassian 연동/troubleshooting.md
@@ -1,0 +1,7 @@
+# Troubleshooting
+
+- 인증 실패: 이메일/토큰/Base URL 재확인, 토큰 재발급
+- 권한 문제: 공간/부모 페이지/프로젝트 권한 점검
+- Jira 스키마: 프로젝트별 필수 필드/이슈 타입 상이 → 에러 메시지 확인
+- 성능/대용량: 본문 분할 또는 storage format 고려
+- MCP 연결: start-mcp-atlassian.sh 로그, 포트/프록시 점검


### PR DESCRIPTION
- 새 디렉터리: `2025년 8월 개발일지/MCP - Atlassian 연동/`
- 추가 파일: README.md, confluence.md, jira.md, troubleshooting.md, scripts.md
- 관련 참고 링크(Confluence/Notion) 포함

필요 시 실제 예시/스크린샷/코드블록을 더 보강하겠습니다.